### PR TITLE
Allow string constants in other file and other package to work

### DIFF
--- a/internal/checkers/common.go
+++ b/internal/checkers/common.go
@@ -6,7 +6,6 @@ import (
 	"go/printer"
 	"go/token"
 	"go/types"
-	"strconv"
 	"unicode/utf8"
 
 	"golang.org/x/tools/go/analysis"
@@ -18,21 +17,11 @@ const (
 	DiagnosticCategory = "logging"
 )
 
-// extractValueFromStringArg returns true if the argument is string literal or string constant.
+// extractValueFromStringArg returns true if the argument is a string type (literal or constant).
 func extractValueFromStringArg(pass *analysis.Pass, arg ast.Expr) (value string, ok bool) {
-	switch arg := arg.(type) {
-	case *ast.BasicLit: // literals, string literals specifically
-		if arg.Kind == token.STRING {
-			if val, err := strconv.Unquote(arg.Value); err == nil {
-				return val, true
-			}
-		}
-	case *ast.Ident: // identifiers, string constants specifically
-		if arg.Obj != nil && arg.Obj.Kind == ast.Con {
-			typeAndValue := pass.TypesInfo.Types[arg]
-			if typ, ok := typeAndValue.Type.(*types.Basic); ok && typ.Kind() == types.String {
-				return constant.StringVal(typeAndValue.Value), true
-			}
+	if typeAndValue, ok := pass.TypesInfo.Types[arg]; ok {
+		if typ, ok := typeAndValue.Type.(*types.Basic); ok && typ.Kind() == types.String && typeAndValue.Value != nil {
+			return constant.StringVal(typeAndValue.Value), true
 		}
 	}
 

--- a/testdata/src/a/requirestringkey/example.go
+++ b/testdata/src/a/requirestringkey/example.go
@@ -5,7 +5,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.uber.org/zap"
+
+	"a/requirestringkey/otherpkg"
 )
+
+const LocalKey1Str = "value1"
 
 func ExampleRequireStringKey() {
 	err := fmt.Errorf("error")
@@ -31,6 +35,9 @@ func ExampleRequireStringKey() {
 
 	const Key1Str = "key1"
 	log.Error(err, "message", Key1Str, "value1")
+	log.Error(err, "message", LocalKey1Str, "value1")
+	log.Error(err, "message", OtherFileKey1Str, "value1")
+	log.Error(err, "message", otherpkg.KeyStr, "value1")
 
 	log.Error(err, "message", "键1", "value1") // want `logging keys are expected to be alphanumeric strings, please remove any non-latin characters from "键1"`
 	const KeyNonASCII = "键1"

--- a/testdata/src/a/requirestringkey/otherfile.go
+++ b/testdata/src/a/requirestringkey/otherfile.go
@@ -1,0 +1,3 @@
+package requirestringkey
+
+const OtherFileKey1Str = "otherfilekey1"

--- a/testdata/src/a/requirestringkey/otherpkg/otherpkg.go
+++ b/testdata/src/a/requirestringkey/otherpkg/otherpkg.go
@@ -1,0 +1,3 @@
+package otherpkg
+
+const KeyStr = "key"


### PR DESCRIPTION
Local string constants (local to the function and local to the file) already work with the existing linter, but as soon as you move the constant into another file, or even another package, the linter starts failing on them.  This pull request fixes this problem.  

The first change shows the unit test changes:

1.  a local file string constant key works.
2. a string constant in the same package but in another file, does NOT work.
3. a string constant in a different package, does NOT work

The second change fixes the above problems.  