### PR TITLE
fix: downgrade minimum Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.23']
+        go: ['1.22', '1.23']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/timonwong/loggercheck
 
-go 1.23
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/internal/checkers/checker.go
+++ b/internal/checkers/checker.go
@@ -30,12 +30,7 @@ func ExecuteChecker(c Checker, pass *analysis.Pass, call CallContext, cfg Config
 	startIndex := nparams - 1
 
 	lastArg := params.At(nparams - 1)
-	if iface, ok := lastArg.Type().(*types.Slice).Elem().(*types.Interface); !ok {
-		aface, ok := lastArg.Type().(*types.Slice).Elem().(*types.Alias) // slog uses any - an Alias not strictly an interface
-		if !ok || !aface.Underlying().(*types.Interface).Empty() {
-			return // final (args) param is not ...interface{}
-		}
-	} else if !iface.Empty() {
+	if !isTypeVariadicEmptyInterface(lastArg.Type()) {
 		return // final (args) param is not ...interface{}
 	}
 

--- a/internal/checkers/filter.go
+++ b/internal/checkers/filter.go
@@ -2,7 +2,6 @@ package checkers
 
 import (
 	"go/ast"
-	"go/types"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -15,19 +14,12 @@ func filterKeyAndValues(pass *analysis.Pass, keyAndValues []ast.Expr, objName st
 		switch arg := arg.(type) {
 		case *ast.CallExpr, *ast.Ident:
 			typ := pass.TypesInfo.TypeOf(arg)
-			switch typ := typ.(type) {
-			case *types.Alias, *types.Named:
-				var obj *types.TypeName
-				if cTyp, ok := typ.(*types.Alias); ok {
-					obj = cTyp.Obj()
-				} else {
-					obj = typ.(*types.Named).Obj()
-				}
+
+			if typ, ok := typ.(commonAlias); ok {
+				obj := typ.Obj()
 				if obj != nil && obj.Name() == objName {
 					continue
 				}
-			default:
-				// pass
 			}
 		}
 

--- a/internal/checkers/types.go
+++ b/internal/checkers/types.go
@@ -1,0 +1,27 @@
+package checkers
+
+import "go/types"
+
+type commonAlias interface {
+	Obj() *types.TypeName
+}
+
+func isTypeVariadicEmptyInterface(typ types.Type) bool {
+	sliceTyp, ok := typ.(*types.Slice)
+	if !ok {
+		return false
+	}
+
+	typ = sliceTyp.Elem()
+	for i := 0; i < 2; i++ {
+		switch iface := typ.(type) {
+		case *types.Interface:
+			return iface.Empty()
+		case *types.Alias:
+			typ = iface.Underlying()
+		default:
+			return false
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Since go1.21, the Go version used inside the `go.mod` is the minimum Go version and it's a hard requirement.

golangci-lint must support compilation with go1.22 and go1.23.

