### PR TITLE
refactor: clarify printf-like message to exclude all format specifiers

### DIFF
--- a/internal/checkers/general.go
+++ b/internal/checkers/general.go
@@ -57,7 +57,7 @@ func (g General) CheckPrintfLikeSpecifier(pass *analysis.Pass, args []ast.Expr) 
 				Pos:      arg.Pos(),
 				End:      arg.End(),
 				Category: DiagnosticCategory,
-				Message:  fmt.Sprintf("logging message should not use format specifier %q", specifier),
+				Message:  fmt.Sprintf("logging message should not contain format specifiers, found %q", specifier),
 			})
 
 			return // One error diagnostic is enough

--- a/testdata/src/a/noprintflike/example.go
+++ b/testdata/src/a/noprintflike/example.go
@@ -23,15 +23,15 @@ func ExamplePrintfLike() {
 	log.Info("%[3]*.[2*[1]f", "intKey", 1)
 
 	// Check message and key value pairs
-	log.Info("message", "key%s", "value %d") // want `logging message should not use format specifier "%s"`
+	log.Info("message", "key%s", "value %d") // want `logging message should not contain format specifiers, found "%s"`
 
-	log.Info("%[3]*s x") // want `logging message should not use format specifier ".+"`
-	log.Info("%[3]d x")  // want `logging message should not use format specifier ".+"`
+	log.Info("%[3]*s x") // want `logging message should not contain format specifiers, found ".+"`
+	log.Info("%[3]d x")  // want `logging message should not contain format specifiers, found ".+"`
 
-	log.Info("% 8s")                        // want `logging message should not use format specifier "% 8s"`
-	log.Info("hello %s", "intKey", 1)       // want `logging message should not use format specifier "%s"`
-	log.Info("%.3[1]f", "intKey", 1)        // want `logging message should not use format specifier ".+"`
-	log.Info("%[3]*.[2]*[1]f", "intKey", 1) // want `logging message should not use format specifier ".+"`
+	log.Info("% 8s")                        // want `logging message should not contain format specifiers, found "% 8s"`
+	log.Info("hello %s", "intKey", 1)       // want `logging message should not contain format specifiers, found "%s"`
+	log.Info("%.3[1]f", "intKey", 1)        // want `logging message should not contain format specifiers, found ".+"`
+	log.Info("%[3]*.[2]*[1]f", "intKey", 1) // want `logging message should not contain format specifiers, found ".+"`
 	const ValidFormat = "hello %#v %32d %f %d %g %% %s %9.2f %w %T %[1]d"
-	log.Info(ValidFormat, "intKey", 1) // want `logging message should not use format specifier "%#v"`
+	log.Info(ValidFormat, "intKey", 1) // want `logging message should not contain format specifiers, found "%#v"`
 }


### PR DESCRIPTION
The previous wording can raise questions and false assumptions that _some_ format specifiers would be ok, but none actually are.