### PR TITLE
feat: detect nil-unsafe Stringer log values

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,3 +100,6 @@ linters:
       - linters:
           - gocritic
         path: internal/checkers/printf/printf.go
+      - linters:
+          - goconst
+        path: ^(loggercheck_test\.go|internal/sets/string_test\.go)$

--- a/internal/checkers/checker.go
+++ b/internal/checkers/checker.go
@@ -2,6 +2,7 @@ package checkers
 
 import (
 	"go/ast"
+	"go/token"
 	"go/types"
 
 	"golang.org/x/tools/go/analysis"
@@ -22,6 +23,43 @@ type Checker interface {
 	FilterKeyAndValues(pass *analysis.Pass, keyAndValues []ast.Expr) []ast.Expr
 	CheckLoggingKey(pass *analysis.Pass, keyAndValues []ast.Expr)
 	CheckPrintfLikeSpecifier(pass *analysis.Pass, args []ast.Expr)
+}
+
+var stringerType = func() *types.Interface {
+	stringMethod := types.NewFunc(token.NoPos, nil, "String", types.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		types.NewTuple(),
+		types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.String])),
+		false,
+	))
+	iface := types.NewInterfaceType([]*types.Func{stringMethod}, nil)
+	iface.Complete()
+	return iface
+}()
+
+func checkStringerValues(pass *analysis.Pass, keyAndValues []ast.Expr) {
+	for i := 1; i < len(keyAndValues); i += 2 {
+		arg := keyAndValues[i]
+		typ := types.Unalias(pass.TypesInfo.TypeOf(arg))
+		ptr, ok := typ.(*types.Pointer)
+		if !ok {
+			continue
+		}
+
+		elem := types.Unalias(ptr.Elem())
+		if !types.Implements(elem, stringerType) || !types.Implements(ptr, stringerType) {
+			continue
+		}
+
+		pass.Report(analysis.Diagnostic{
+			Pos:      arg.Pos(),
+			End:      arg.End(),
+			Category: DiagnosticCategory,
+			Message:  "logging value may panic when nil because its element type implements fmt.Stringer",
+		})
+	}
 }
 
 func ExecuteChecker(c Checker, pass *analysis.Pass, call CallContext, cfg Config) {
@@ -50,6 +88,8 @@ func ExecuteChecker(c Checker, pass *analysis.Pass, call CallContext, cfg Config
 	if cfg.RequireStringKey {
 		c.CheckLoggingKey(pass, keyValuesArgs)
 	}
+
+	checkStringerValues(pass, keyValuesArgs)
 
 	if cfg.NoPrintfLike {
 		// Check all args

--- a/testdata/src/a/all/example.go
+++ b/testdata/src/a/all/example.go
@@ -13,6 +13,43 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type valueStringer struct{}
+
+func (valueStringer) String() string { return "value" }
+
+type pointerStringer struct{}
+
+func (*pointerStringer) String() string { return "pointer" }
+
+type interfaceStringer interface {
+	String() string
+}
+
+type embeddedStringer struct {
+	time.Time
+}
+
+func ExampleStringerValues() {
+	var value *valueStringer
+	var pointer *pointerStringer
+	var embedded *embeddedStringer
+	var ordinary *int
+	var pointerToInterface *interfaceStringer
+
+	log := logr.Discard()
+	log.Info("value receiver", "value", value) // want `logging value may panic when nil because its element type implements fmt.Stringer`
+	log.Info("pointer receiver", "value", pointer)
+	log.Info("promoted receiver", "value", embedded) // want `logging value may panic when nil because its element type implements fmt.Stringer`
+	log.Info("ordinary pointer", "value", ordinary)
+	log.Info("non-pointer stringer", "value", valueStringer{})
+	log.Info("pointer to interface", "value", pointerToInterface)
+
+	klog.InfoS("value receiver", "value", value)    // want `logging value may panic when nil because its element type implements fmt.Stringer`
+	zap.S().Infow("value receiver", "value", value) // want `logging value may panic when nil because its element type implements fmt.Stringer`
+	slog.Info("value receiver", "value", value)     // want `logging value may panic when nil because its element type implements fmt.Stringer`
+	kitlog.NewNopLogger().Log("value", value)       // want `logging value may panic when nil because its element type implements fmt.Stringer`
+}
+
 func ExampleInvalid() {
 	// function pointer is not supported
 

--- a/testdata/src/a/customonly/example.go
+++ b/testdata/src/a/customonly/example.go
@@ -7,6 +7,10 @@ import (
 	"github.com/go-logr/logr"
 )
 
+type valueStringer struct{}
+
+func (valueStringer) String() string { return "value" }
+
 func logrIgnored() {
 	err := fmt.Errorf("error")
 
@@ -20,6 +24,8 @@ func logrIgnored() {
 func ExampleCustomLogger() {
 	err := errors.New("example error")
 
+	var valueStringerPtr *valueStringer
+
 	// custom SugaredLogger
 	log := New()
 	defer log.Sync()
@@ -28,6 +34,7 @@ func ExampleCustomLogger() {
 	log.XXXDebugw("message", "key1")
 
 	log.Infow("abc", "key1", "value1")
+	log.Infow("abc", "key1", valueStringerPtr) // want `logging value may panic when nil because its element type implements fmt.Stringer`
 	log.Infow("abc", "key1", "value1", "key2") // want `odd number of arguments passed as key-value pairs for logging`
 
 	log.Errorw("message", "err", err, "key1", "value1")


### PR DESCRIPTION
## Summary

- Detect `*T` logging values where `T` and `*T` implement `fmt.Stringer`.
- Report the nil-unsafe value-receiver and promoted-method case across the shared checker path.
- Cover built-in logger checkers and custom rules with positive and negative analyzer fixtures.

Closes #109

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
