### PR TITLE
fix: avoid panic on multi-valued logger arguments

### DIFF
--- a/internal/checkers/checker.go
+++ b/internal/checkers/checker.go
@@ -67,6 +67,13 @@ func ExecuteChecker(c Checker, pass *analysis.Pass, call CallContext, cfg Config
 	nparams := params.Len() // variadic => nonzero
 	startIndex := nparams - 1
 
+	if len(call.Expr.Args) < startIndex {
+		// A multi-valued expression may expand to multiple arguments, but its
+		// individual values cannot be represented by separate AST expressions.
+		// Skip calls whose syntactic arguments cannot cover the fixed params.
+		return
+	}
+
 	iface, ok := types.Unalias(params.At(startIndex).Type().(*types.Slice).Elem()).(*types.Interface)
 	if !ok || !iface.Empty() {
 		return // final (args) param is not ...interface{}

--- a/loggercheck_test.go
+++ b/loggercheck_test.go
@@ -64,6 +64,21 @@ func TestLinter(t *testing.T) {
 			},
 		},
 		{
+			name:     "issue-108-multi-valued-helper",
+			patterns: "a/issue108",
+			flags:    []string{"-disable="},
+		},
+		{
+			name:     "issue-108-multi-valued-helper-require-string-key",
+			patterns: "a/issue108",
+			flags:    []string{"-disable=", "-requirestringkey"},
+		},
+		{
+			name:     "issue-108-multi-valued-helper-no-printf-like",
+			patterns: "a/issue108",
+			flags:    []string{"-disable=", "-noprintflike"},
+		},
+		{
 			name:     "wrong-rules",
 			patterns: "a/customonly",
 			flags: []string{

--- a/testdata/src/a/issue108/example.go
+++ b/testdata/src/a/issue108/example.go
@@ -1,0 +1,23 @@
+package issue108
+
+import (
+	"context"
+	"log/slog"
+)
+
+func ExampleMultiValuedHelper() {
+	slog.ErrorContext(fn())
+	slog.InfoContext(fn())
+	slog.Default().WarnContext(fn())
+	slog.Default().ErrorContext(fn())
+	slog.Info(keyValues())
+	slog.Default().Info(keyValues())
+}
+
+func fn() (context.Context, string) {
+	return nil, "test"
+}
+
+func keyValues() (string, string, string) {
+	return "msg", "key", "value"
+}


### PR DESCRIPTION
## Summary

- prevent loggercheck from panicking when a variadic logger call uses a multi-valued helper expression for fixed parameters
- add regression coverage for package-level and receiver-based `slog` context methods
- exercise the regression with `-requirestringkey` and `-noprintflike`

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #108
